### PR TITLE
updated ModelLock.php for Laravel 5.7 support

### DIFF
--- a/src/ModelLock.php
+++ b/src/ModelLock.php
@@ -25,6 +25,8 @@ class ModelLock extends Model
      */
     protected static function boot()
     {
+        parent::boot();
+
         static::saving(function ($lock) {
             if (!$lock->isDirty('locked_until')) {
                 $lock->locked_until = $lock->lockTimestamp();


### PR DESCRIPTION
called parent::boot inside the boot method of ModelLock.php 
see: https://github.com/laravel/framework/issues/25455

as requested in https://github.com/jarektkaczyk/model-locking/pull/11