### PR TITLE
Added the ability to disable broadcasting

### DIFF
--- a/published/config.stub
+++ b/published/config.stub
@@ -66,4 +66,11 @@ return [
         Sofa\ModelLocking\ModelLocked::class => null,
         Sofa\ModelLocking\ModelUnlocked::class => null,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Determine if the package should broadcast events.
+    |--------------------------------------------------------------------------
+    */
+    'broadcast_enabled' => env('MODEL_LOCKING_BROADCAST_ENABLED', true),
 ];

--- a/src/LockEvent.php
+++ b/src/LockEvent.php
@@ -49,4 +49,14 @@ abstract class LockEvent implements ShouldBroadcast
     {
         return config('model_locking.broadcast_as.'.static::class) ?: static::class;
     }
+
+    /**
+     * Determine if this event should broadcast.
+     *
+     * @return bool
+     */
+    public function broadcastWhen()
+    {
+        return config('model_locking.broadcast_enabled', true);
+    }
 }


### PR DESCRIPTION
Laravel has a new handy `broadcastWhen` method (https://laravel.com/docs/5.8/broadcasting#broadcast-conditions), which lets you control if you really want to broadcast even you are implementing the interface.

This PR implements this method and a config value, so you can disable broadcasting where you don't want.