### PR TITLE
Fixes #10 ability to disable event broadcasting via a config option.

### DIFF
--- a/published/config.stub
+++ b/published/config.stub
@@ -66,4 +66,11 @@ return [
         Sofa\ModelLocking\ModelLocked::class => null,
         Sofa\ModelLocking\ModelUnlocked::class => null,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable event broadcasting?
+    |--------------------------------------------------------------------------
+    */
+    'enable_broadcasting' => true,
 ];

--- a/src/LockEvent.php
+++ b/src/LockEvent.php
@@ -49,4 +49,14 @@ abstract class LockEvent implements ShouldBroadcast
     {
         return config('model_locking.broadcast_as.'.static::class) ?: static::class;
     }
+
+    /**
+     * Determine if this event should broadcast.
+     *
+     * @return bool
+     */
+    public function broadcastWhen()
+    {
+        return config('model_locking.enable_broadcasting');
+    }
 }


### PR DESCRIPTION
added a config option for disabling event broadcasting. useful for Pusher users using Pusher elsewhere in their app.