### PR TITLE
Make compatible with Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/database": "^5.5",
-        "illuminate/queue": "^5.5"
+        "illuminate/database": ">=5.5",
+        "illuminate/queue": ">=5.5"
     },
     "require-dev": {
         "kahlan/kahlan": "~2.5"


### PR DESCRIPTION
Updated the dependencies to make it installable for Laravel 6 projects.
Seems to work fine in that context.