### PR TITLE
[FEATURE] Configurable broadcast queue

### DIFF
--- a/published/config.stub
+++ b/published/config.stub
@@ -66,4 +66,11 @@ return [
         Sofa\ModelLocking\ModelLocked::class => null,
         Sofa\ModelLocking\ModelUnlocked::class => null,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue where broadcasts are dispatched to.
+    |--------------------------------------------------------------------------
+    */
+    'broadcast_queue' => null,
 ];

--- a/src/LockEvent.php
+++ b/src/LockEvent.php
@@ -22,6 +22,16 @@ abstract class LockEvent implements ShouldBroadcast
     }
 
     /**
+     * Get the queue where broadcasts are dispatched to.
+     *
+     * @return string|null
+     */
+    public function broadcastQueue()
+    {
+        return config('model_locking.broadcast_queue');
+    }
+
+    /**
      * Get the channels the event should broadcast on.
      *
      * @return array


### PR DESCRIPTION
If not specified broadcast events are pushed in **default** queue
This PR adds a config option to specify broadcast queue